### PR TITLE
Fix RegExp whitelist pattern for windows dev

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -11,7 +11,7 @@ exports.onCreateWebpackConfig = ({ actions, loaders }, { modules = [] }) => {
             /node_modules/.test(modulePath) &&
             // whitelist specific es6 module
             !new RegExp(
-              `node_modules\/(${modules.map(regexEscape).join("|")})\/`
+              `node_modules[\\\\/](${modules.map(regexEscape).join("|")})[\\\\/]`
             ).test(modulePath),
           use: loaders.js()
         }


### PR DESCRIPTION
Current `RegExp` whitelist pattern does not work on a `Windows` machine. The changes fix that.