### PR TITLE
Fix inclusion rule

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -10,10 +10,9 @@ exports.onCreateWebpackConfig = (
       rules: [
         {
           test,
-          exclude: modulePath =>
-            /node_modules/.test(modulePath) &&
+          include: modulePath =>
             // whitelist specific es6 module
-            !new RegExp(
+            new RegExp(
               `node_modules[\\\\/](${modules
                 .map(module => module.replace(/\//, path.sep))
                 .map(regexEscape)


### PR DESCRIPTION
Before my fix the loader has been applied to application source because:
```
/node_modules/.test('src/foo.j')
```
returns false and thus this `exclude` rule has been returning false which meant that this had to process source file again.